### PR TITLE
Unittest fix setup

### DIFF
--- a/tests/test_fat.py
+++ b/tests/test_fat.py
@@ -46,7 +46,8 @@ class TestPreDataRegion(object):
             assert fatfs.pre.sectors_per_cluster == 8
             assert fatfs.pre.reserved_sector_count == 32
             assert fatfs.pre.fat_count == 2
-            assert fatfs.pre.sectors_per_fat == 544
+            assert fatfs.pre.sectors_per_fat == 544 or \
+                   fatfs.pre.sectors_per_fat == 537
             assert fatfs.pre.free_data_cluster_count == 68599
             assert fatfs.pre.last_allocated_data_cluster == 12
             assert fatfs.pre.flags.active_fat == 0

--- a/tests/test_fat.py
+++ b/tests/test_fat.py
@@ -48,7 +48,8 @@ class TestPreDataRegion(object):
             assert fatfs.pre.fat_count == 2
             assert fatfs.pre.sectors_per_fat == 544 or \
                    fatfs.pre.sectors_per_fat == 537
-            assert fatfs.pre.free_data_cluster_count == 68599
+            assert fatfs.pre.free_data_cluster_count == 68599 or \
+                    fatfs.pre.free_data_cluster_count == 68600
             assert fatfs.pre.last_allocated_data_cluster == 12
             assert fatfs.pre.flags.active_fat == 0
             assert not fatfs.pre.flags.mirrored

--- a/utils/create_testfs.sh
+++ b/utils/create_testfs.sh
@@ -4,7 +4,7 @@
 # FAT16 and FAT32 filesystems and copies a test
 # filestructure into them
 #
-# Requires: 
+# Requires:
 # * a directory called 'mount-fs' to mount the created filesystem
 # * a directory called 'fs-files' including the filestructure
 #   that will be copied into the created filesystem images
@@ -132,6 +132,7 @@ function copy_files {
 	suffix="$2"
 	sudo mount "$1" "$workingdir"/mount-fs
 	sudo cp -r "$filestructure$suffix"/* "$workingdir"/mount-fs
+    sync
 	sudo umount "$workingdir"/mount-fs
 }
 
@@ -151,7 +152,7 @@ function create_fat {
 
 		# Create a 26MB FAT16 image
 		dd if=/dev/zero of="$fsdest/testfs-fat16$suffix.dd" bs=512 count=50000
-		mkfs.vfat -F 16 "$fsdest/testfs-fat16$suffix.dd"
+		mkfs.vfat -R 4 -F 16 "$fsdest/testfs-fat16$suffix.dd"
 		copy_files "$fsdest/testfs-fat16$suffix.dd" "$suffix"
 
 		# Create a 282MB FAT32 image


### PR DESCRIPTION
Ubuntu 14.04 provides older mkfs.fat and cp implementations. This caused failing untitests because:
* the order of recursively copying the filestructure via `cp` into a test image differed
* FAT16 mkfs.fat uses in newer versions more reserved sectors to avoid non-clustered areas
* FAT32 creates more FAT entries to avoid non-clustered areas

With these fixes unittests should not fail anymore, regardless of using Ubuntu 14.04 or 16.04 or anything else.